### PR TITLE
Fix exception in 'yum repolist'.

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -57,8 +57,8 @@ def init_hook(conduit):
     repos = conduit.getRepos()
     for key, repo in repos.repos.iteritems():
         if isinstance(repo, YumRepository) and repo.s3_enabled and repo.enabled:
-            print "s3iam: found S3 private repository"
             new_repo = S3Repository(repo.id, repo.baseurl)
+            new_repo.name = repo.name
             repos.delete(key)
             repos.add(new_repo)
 


### PR DESCRIPTION
The `yum repolist` command throws the following exception:

```
[root@ip-10-10-26-99 ~]# yum repolist
Loaded plugins: priorities, s3iam, security, update-motd, upgrade-helper
s3iam: found S3 private repository
amzn-main                                                                                                                                                                             | 2.1 kB     00:00     
amzn-updates                                                                                                                                                                          | 2.3 kB     00:00     
Traceback (most recent call last):
  File "/usr/bin/yum", line 29, in <module>
    yummain.user_main(sys.argv[1:], exit_code=True)
  File "/usr/share/yum-cli/yummain.py", line 285, in user_main
    errcode = main(args)
  File "/usr/share/yum-cli/yummain.py", line 136, in main
    result, resultmsgs = base.doCommands()
  File "/usr/share/yum-cli/cli.py", line 438, in doCommands
    return self.yum_cli_commands[self.basecmd].doCommand(self, self.basecmd, self.extcmds)
  File "/usr/share/yum-cli/yumcommands.py", line 1027, in doCommand
    if nm_len < utf8_width(rname):
  File "/usr/lib/python2.6/site-packages/yum/i18n.py", line 218, in utf8_width
    for (ucs, bytes) in __utf8_iter_ucs(msg):
  File "/usr/lib/python2.6/site-packages/yum/i18n.py", line 174, in __utf8_iter_ucs
    for byte0 in uiter:
  File "/usr/lib/python2.6/site-packages/yum/i18n.py", line 170, in __utf8_iter_ints
    for byte in to_utf8(msg):
TypeError: 'NoneType' object is not iterable
```

It appears that the command expects each repo object to have a `name` property.  This patch adds it.

I removed the `print` statement since it appears to be debugging code.
