### PR TITLE
Making RPM package noarch

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -7,7 +7,9 @@ Group:    Application/SystemTools
 License:  Apache License Version 2.0, January 2004
 URL:		  https://github.com/seporaitis/yum-s3-iam
 Source0:	%{name}-%{version}.tar.gz
-BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildArch: noarch
 
 Requires:	yum
 


### PR DESCRIPTION
The RPM package should be noarch, since it's just interpreted python...  Thanks!
