### PR TITLE
convert + to %2B

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -159,7 +159,7 @@ class S3Grabber(object):
         self.token = data['Token']
 
     def _request(self, path):
-        url = urlparse.urljoin(self.baseurl, path).replace('+','%2B')
+        url = urlparse.urljoin(self.baseurl, urllib2.quote(path))
         request = urllib2.Request(url)
         request.add_header('x-amz-security-token', self.token)
         signature = self.sign(request)


### PR DESCRIPTION
This is a PR which implements Rvdkerkhoff's fix for a + in the package name (such as gcc-c++).

Closes #15
