### PR TITLE
URL encode package names to allow packages with "+" in the name

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -21,6 +21,7 @@ __license__ = "Apache 2.0"
 __version__ = "1.0.1"
 
 
+import urllib
 import urllib2
 import urlparse
 import time
@@ -159,7 +160,7 @@ class S3Grabber(object):
         self.token = data['Token']
 
     def _request(self, path):
-        url = urlparse.urljoin(self.baseurl, path)
+        url = urlparse.urljoin(self.baseurl, urllib.quote_plus(path))
         request = urllib2.Request(url)
         request.add_header('x-amz-security-token', self.token)
         signature = self.sign(request)


### PR DESCRIPTION
I was getting a 404 error when trying to install packages from S3 that included "+" in the filename. This seems to fix that.
