### PR TITLE
Support Python 2.4, for the benefit of Centos 5

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -34,7 +34,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %doc s3iam.repo
 %doc LICENSE NOTICE README.md
 /etc/yum/pluginconf.d/s3iam.conf
-/usr/lib/yum-plugins/s3iam.py
+/usr/lib/yum-plugins/s3iam.py*
 
 %changelog
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1

--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -12,6 +12,9 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 
 Requires:	yum
+%if ! (0%{?rhel} > 5)
+Requires: python-simplejson python-hashlib
+%endif
 
 %description
 Yum package manager plugin for private S3 repositories. 


### PR DESCRIPTION
Centos 5 still ships with Python 2.4, so here's a change which make s3iam.py compatible with it.

I've also updated the RPM spec to include the two dependencies: python-simplejson is in the core OS, but python-hashlib comes from EPEL, unfortunately. 
