### PR TITLE
Package pyc and pyo byte compiled files

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -34,7 +34,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %doc s3iam.repo
 %doc LICENSE NOTICE README.md
 /etc/yum/pluginconf.d/s3iam.conf
-/usr/lib/yum-plugins/s3iam.py
+/usr/lib/yum-plugins/s3iam.py*
 
 %changelog
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1


### PR DESCRIPTION
These are automatically built with rpmbuild via /usr/lib/rpm/brp-python-bytecompile.