### PR TITLE
Rework build system

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,22 @@
+name: "CodeQL"
+
+on:
+  # workflow_dispatch enables manual triggering of the workflow
+  workflow_dispatch:
+  schedule:
+  - cron: '59 21 * * 5'
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: S24 static application security testing (SAST) action
+      uses: scout24/s24-sast-action@v1
+      with:
+        languages: python
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 test_values.py
 *.pyc
 *.pyo
+dist
+build

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
-NAME				= yum-plugin-s3-iam
-VERSION			= 1.0
-RELEASE			= 1
-ARCH				= noarch
+# set EXTRAREV to append something to the RPM revision, e.g. EXTRAREV=.is24
 
-RPM_TOPDIR ?= $(shell rpm --eval '%{_topdir}')
+# this goes into the src archive and this is relevant for the revision
+TOPLEVEL = LICENSE  Makefile  NOTICE  README.md  s3iam.conf  s3iam.py  s3iam.repo  tests.py  yum-plugin-s3-iam.spec
 
-RPMBUILD_ARGS := \
-	--define "name $(NAME)" \
-	--define "version $(VERSION)" \
-	--define "release $(RELEASE)"
+GITREV := HEAD
 
-.PHONY: all rpm install
+NAME=yum-plugin-s3-iam
+ARCH=noarch
+VERSION := $(shell git rev-list $(GITREV) -- $(TOPLEVEL) 2>/dev/null| wc -l)
+RELEASE := 1$(EXTRAREV)
+PV := $(NAME)-$(VERSION)
 
-all:
-	@echo "Usage: make rpm"
+.PHONY: all test srpm clean rpm info rpminfo install
+
+all: rpminfo
+	ls -l dist/
 
 install:
 	install -m 0755 -d $(DESTDIR)/etc/yum/pluginconf.d/
@@ -21,15 +22,43 @@ install:
 	install -m 0755 -d $(DESTDIR)/usr/lib/yum-plugins/
 	install -m 0644 s3iam.py $(DESTDIR)/usr/lib/yum-plugins/
 
-rpm:
-	mkdir -p $(RPM_TOPDIR)/SOURCES
-	mkdir -p $(RPM_TOPDIR)/SPECS
-	mkdir -p $(RPM_TOPDIR)/BUILD
-	mkdir -p $(RPM_TOPDIR)/RPMS/$(ARCH)
-	mkdir -p $(RPM_TOPDIR)/SRPMS
-	rm -Rf $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)
-	cp -r . $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)
-	tar czf $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION).tar.gz -C $(RPM_TOPDIR)/SOURCES --exclude ".git" $(NAME)-$(VERSION)
-	rm -Rf $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)
-	cp $(NAME).spec $(RPM_TOPDIR)/SPECS/
-	rpmbuild $(RPMBUILD_ARGS) -ba --clean $(NAME).spec
+tgz: clean
+	@echo "Creating TAR.GZ"
+	mkdir -p dist build/$(PV) build/BUILD
+	cp -r $(TOPLEVEL) build/$(PV)
+	mv build/$(PV)/*.spec build/
+	sed -i -e "s/__VERSION__/$(VERSION)/" -e "s/__RELEASE__/$(RELEASE)/" -e "s/__NAME__/$(NAME)/" build/*.spec build/$(PV)/*.py
+	tar -czf dist/$(PV).tar.gz -C build $(PV)
+
+srpm: tgz
+	@echo "Creating SOURCE RPM"
+	rpmbuild $(RPMBUILD_OPTS) --define="_topdir $(CURDIR)/build" --define="_sourcedir $(CURDIR)/dist" --define="_srcrpmdir $(CURDIR)/dist" --nodeps -bs build/*.spec
+
+rpm: srpm
+	@echo "Creating BINARY RPM"
+	ln -svf ../dist build/noarch
+	rpmbuild $(RPMBUILD_OPTS) --define="_topdir $(CURDIR)/build" --define="_rpmdir %{_topdir}" --rebuild $(CURDIR)/dist/*.src.rpm
+	@echo
+	@echo
+	@echo
+	@echo 'WARNING! THIS RPM IS NOT INTENDED FOR PRODUCTION USE. PLEASE USE rpmbuild --rebuild dist/*.src.rpm TO CREATE A PRODUCTION RPM PACKAGE!'
+	@echo
+	@echo
+	@echo
+
+info: rpminfo
+
+rpminfo: rpm
+	rpm -qip dist/*.noarch.rpm
+
+rpmrepo: rpm
+	repoclient uploadto "$(TARGET_REPO)" dist/*.rpm
+	echo "##teamcity[buildStatus text='{build.status.text} RPM Version $(shell rpm -qp dist/*src.rpm --queryformat "%{VERSION}-%{RELEASE}") in $(TARGET_REPO)']"
+
+clean:
+	rm -Rf dist build test
+
+
+
+# todo: create debian/RPM changelog automatically, e.g. with git-dch --full --id-length=10 --ignore-regex '^fixes$' -S -s 68809505c5dea13ba18a8f517e82aa4f74d79acb src doc *.spec
+

--- a/s3iam.py
+++ b/s3iam.py
@@ -18,7 +18,7 @@ __author__ = "Julius Seporaitis"
 __email__ = "julius@seporaitis.net"
 __copyright__ = "Copyright 2012, Julius Seporaitis"
 __license__ = "Apache 2.0"
-__version__ = "1.0.1"
+__version__ = "__VERSION__"
 
 
 import urllib2

--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -1,17 +1,18 @@
-Name:     %{name}
-Version:	%{version}
-Release:	%{release}
+Name:       __NAME__
+Version:	__VERSION__
+Release:	__RELEASE__
 Summary:	Yum package manager plugin for private S3 repositories.
 
-Group:    Application/SystemTools
-License:  Apache License Version 2.0, January 2004
-URL:		  https://github.com/seporaitis/yum-s3-iam
-Source0:	%{name}-%{version}.tar.gz
+Group:      Application/SystemTools
+License:    Apache License Version 2.0, January 2004
+URL:        https://github.com/seporaitis/yum-s3-iam
+Source0:    %{name}-%{version}.tar.gz
 
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildArch: noarch
+BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildArch:  noarch
 
 Requires:	yum
+BuildRequires: yum
 
 %description
 Yum package manager plugin for private S3 repositories. 
@@ -21,6 +22,7 @@ Uses Amazon IAM & EC2 Roles.
 %setup -q
 
 %build
+python tests.py 
 
 %install
 rm -rf $RPM_BUILD_ROOT
@@ -32,9 +34,9 @@ rm -rf ${RPM_BUILD_ROOT}
 %files
 %defattr(-,root,root,-)
 %doc s3iam.repo
-%doc LICENSE NOTICE README.md
-/etc/yum/pluginconf.d/s3iam.conf
-/usr/lib/yum-plugins/s3iam.py
+%doc *E*
+/etc/yum/pluginconf.d/*
+/usr/lib/yum-plugins/*
 
 %changelog
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1


### PR DESCRIPTION
- build in local directory instead of user homedir
- use count of git revisions as version -> constantly increasing
- build via src.rpm so that production use can build rpm from src.rpm in mock environment
- add support for direct uploading to yum repo server (https://github.com/immobilienscout24/yum-repo-server)
