### PR TITLE
config file in spec

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -33,8 +33,8 @@ rm -rf ${RPM_BUILD_ROOT}
 %defattr(-,root,root,-)
 %doc s3iam.repo
 %doc LICENSE NOTICE README.md
-/etc/yum/pluginconf.d/s3iam.conf
-/usr/lib/yum-plugins/s3iam.py
+%config /etc/yum/pluginconf.d/s3iam.conf
+/usr/lib/yum-plugins/s3iam.py*
 
 %changelog
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1


### PR DESCRIPTION
s3iam.conf file should be marked as %config in specification so it will not be rewritten. Not all files are included into package from build dir - this causes an error. 
