### PR TITLE
Add support for s3:// scheme for baseurl so s3_enabled is no longer nece...

### DIFF
--- a/s3iam.repo
+++ b/s3iam.repo
@@ -18,6 +18,8 @@
 [s3iam]
 name=S3 yum plugin test repository config
 baseurl=http://your-bucket-name.s3.amazonaws.com/
+# Alternatively you can use the s3:// scheme.
+#basename=s3://your-bucket-name.s3.amazonaws.com/
 failovermethod=priority
 enabled=1
 s3_enabled=1

--- a/tests.py
+++ b/tests.py
@@ -100,6 +100,20 @@ class YumTestCase(unittest.TestCase):
         available = yumbase.doPackageLists().available
         self.assertEqual([p.name for p in available], [PACKAGE_NAME])
 
+    def test_s3_scheme(self):
+        if not RPM_FILE:
+            print >>sys.stderr, 'Skipping:', 'Rpm file required'
+            return
+        # copy rpm file to tmpdir and create repodata
+        shutil.copyfile(RPM_FILE, os.path.join(self.tmpdir, 's3iam.rpm'))
+        self._createrepo()
+
+        yumbase = self._init_yum(
+            baseurl='s3://test.s3.amazonaws.com',
+        )
+        available = yumbase.doPackageLists().available
+        self.assertEqual([p.name for p in available], [PACKAGE_NAME])
+
     def test_repo_unavailable(self):
         self._createrepo()
 


### PR DESCRIPTION
...ssary.  Automatically changes s3:// to https:// and sets repo.s3_enabled.

Example from a yum repo conf:
`baseurl=s3://my-bucket-yum-repo.s3.amazonaws.com`

I'm not certain I did the right thing for the tests.  If not, some advice would be appreciated.