### PR TITLE
Fix for trailing line-feed on signature (fixes seporaitis/yum-s3-iam#33)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME				= yum-plugin-s3-iam
-VERSION			= 1.0
+VERSION			= 1.0.1
 RELEASE			= 1
 ARCH				= noarch
 

--- a/s3iam.py
+++ b/s3iam.py
@@ -259,4 +259,4 @@ class S3Grabber(object):
             str(sigstring),
             hashlib.sha1).digest()
         signature = digest.encode('base64')
-        return signature
+        return signature.strip()

--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -37,5 +37,8 @@ rm -rf ${RPM_BUILD_ROOT}
 /usr/lib/yum-plugins/s3iam.py*
 
 %changelog
+* Mon Sep 21 2015 Mathias Brossard <mathias@brossard.org> 1.0.1-1
+Fix for trailing line-feed on signature
+
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1
 Initial packaging


### PR DESCRIPTION
digest.encode('base64') will always return an extraneous "\n", adding a call to strip() to remove it.

As indicated in #33 newer versions of httplib fail because of this "\n".

With those I built the RPM package and tested it successfully with RedHat Enterprise Linux 6 and Amazon Linux 2015-09.