### PR TITLE
trim whitespace from aws signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME				= yum-plugin-s3-iam
 VERSION			= 1.0
-RELEASE			= 1
+RELEASE			= 2
 ARCH				= noarch
 
 RPM_TOPDIR ?= $(shell rpm --eval '%{_topdir}')

--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Apache 2.0 license. See LICENSE.
 - Julius Seporaitis
 - [Robert Melas' code](https://github.com/rmela/yum-s3-plugin/) was
   used as a reference. See NOTICE.
+- Mischa Spiegelmock (fixed urllib2 error)

--- a/s3iam.py
+++ b/s3iam.py
@@ -18,7 +18,7 @@ __author__ = "Julius Seporaitis"
 __email__ = "julius@seporaitis.net"
 __copyright__ = "Copyright 2012, Julius Seporaitis"
 __license__ = "Apache 2.0"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 import urllib2
@@ -178,6 +178,7 @@ class S3Grabber(object):
         if self.token:
             request.add_header('x-amz-security-token', self.token)
         signature = self.sign(request)
+        signature = signature.strip()
         request.add_header('Authorization', "AWS {0}:{1}".format(
             self.access_key,
             signature))


### PR DESCRIPTION
This is causing an error because of trailing whitespace on the AWS signature. New versions of urllib2 complain with "Invalid header value"