### PR TITLE
Stripping returned signature due to trailing newline

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -259,4 +259,4 @@ class S3Grabber(object):
             str(sigstring),
             hashlib.sha1).digest()
         signature = digest.encode('base64')
-        return signature
+        return signature.strip()


### PR DESCRIPTION
Had an issue with instances not being able to request repository data

```
  File "/usr/lib/yum-plugins/s3iam.py", line 182, in urlgrab
    response = urllib2.urlopen(request)
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1229, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1196, in do_open
    h.request(req.get_method(), req.get_selector(), req.data, headers)
  File "/usr/lib64/python2.7/httplib.py", line 1053, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib64/python2.7/httplib.py", line 1092, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib64/python2.7/httplib.py", line 1031, in putheader
    raise ValueError('Invalid header value %r' % (one_value,))
ValueError: Invalid header value 'AWS ************************:*****************************\n'
```
