### PR TITLE
various changes and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test_values.py
 *.pyc
 *.pyo
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0.2 (2015-11-03)
+- Fix signature issue with python 2.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:6
+
+RUN yum -y install createrepo rpm-build && yum clean all
+
+WORKDIR /tmp/
+
+ADD . /tmp/
+ADD tests.py /tmp/s3iam_tests.py
+RUN make rpm
+RUN echo $REPO > /etc/yum.repos.d/s3iam.repo
+
+CMD ["python", "/tmp/s3iam_tests.py"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ NAME				= yum-plugin-s3-iam
 VERSION			= 1.0.2
 RELEASE			= 1
 ARCH				= noarch
+OWNER 		  = pbase
+IMAGE       = $(OWNER)/$(NAME)
 
 RPM_TOPDIR ?= $(shell rpm --eval '%{_topdir}')
 
@@ -10,7 +12,7 @@ RPMBUILD_ARGS := \
 	--define "version $(VERSION)" \
 	--define "release $(RELEASE)"
 
-.PHONY: all rpm install test
+.PHONY: all rpm install test dtest dshell
 
 all:
 	@echo "Usage: make rpm"
@@ -36,3 +38,12 @@ rpm:
 
 test: rpm
 	python tests.py
+
+dshell:
+	export REPO=$$(cat s3iam.repo ) && docker run -e REPO="$$REPO" -it $(IMAGE):latest /bin/bash
+
+dbuild:
+	docker build -t $(IMAGE) .
+
+dtest: dbuild
+	docker run $(IMAGE):latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME				= yum-plugin-s3-iam
-VERSION			= 1.0.1
+VERSION			= 1.0.2
 RELEASE			= 1
 ARCH				= noarch
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,59 @@ use this plugin:
 
 ## Testing
 
-Use `make test` to run some simple tests.
+### Unit testing
+* Use `make test` to run some simple tests.
+
+### Integration Testing (with Docker)
+
+The test is run in the containerized environment, based on [centos:6](https://hub.docker.com/_/centos/) Docker image.
+* The usual pre-requisites are necessary to configure docker runtime and they're not covered here.
+Make sure you can run `docker ps` successfully before starting.
+* Use `make dtest` to run integration test in a docker container.
+ Sample output:
+
+```
+(default) ❯ make dtest
+docker build -t pbase/yum-plugin-s3-iam .
+Sending build context to Docker daemon 567.3 kB
+Step 1 : FROM centos:6
+ ---> ed452988fb6e
+Step 2 : RUN yum -y install createrepo rpm-build && yum clean all
+ ---> Using cache
+ ---> ffe4e2c9256f
+Step 3 : WORKDIR /tmp/
+ ---> Using cache
+ ---> f7e45933a0f8
+Step 4 : ADD . /tmp/
+ ---> df825cd111c7
+Removing intermediate container 4a52af4336e7
+Step 5 : ADD tests.py /tmp/s3iam_tests.py
+ ---> 13e5ec064062
+Removing intermediate container 86ecb5cb7478
+Step 6 : RUN make rpm
+ ---> Running in 8d70496f764d
+ ---> 76d497363a83
+Removing intermediate container 8d70496f764d
+Step 7 : RUN echo $REPO > /etc/yum.repos.d/s3iam.repo
+ ---> Running in d494f22a7d11
+ ...
+ ---> f18f8c10b97f
+Removing intermediate container d494f22a7d11
+Step 8 : CMD python /tmp/s3iam_tests.py
+ ---> Running in d87f96a3f19b
+ ---> 309c415ce206
+Removing intermediate container d87f96a3f19b
+Successfully built 309c415ce206
+docker run pbase/yum-plugin-s3-iam:latest
+........................
+----------------------------------------------------------------------
+Ran 24 tests in 4.138s
+
+OK
+
+```
+
+Please see [Dockerfile](./Dockerfile) for more information
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Apache 2.0 license. See LICENSE.
 - Mathias Brossard
 - Mischa Spiegelmock
 - Sean Edge
+- [Michal Bicz](https://github.com/bemehow)
 
 ## Author(s)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Use `make test` to run some simple tests.
 
 Apache 2.0 license. See LICENSE.
 
+## Maintainers
+
+- Mathias Brossard
+- Mischa Spiegelmock
+- Sean Edge
+
 ## Author(s)
 
 - Julius Seporaitis

--- a/s3iam.py
+++ b/s3iam.py
@@ -18,7 +18,7 @@ __author__ = "Julius Seporaitis"
 __email__ = "julius@seporaitis.net"
 __copyright__ = "Copyright 2012, Julius Seporaitis"
 __license__ = "Apache 2.0"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 import urllib2

--- a/s3iam.py
+++ b/s3iam.py
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 __author__ = "Julius Seporaitis"
 __email__ = "julius@seporaitis.net"
 __copyright__ = "Copyright 2012, Julius Seporaitis"
 __license__ = "Apache 2.0"
-__version__ = "1.0.2"
-
+__version__ = "1.1.0"
 
 import urllib2
 import urlparse
@@ -27,13 +25,20 @@ import time
 import hashlib
 import hmac
 import json
+import sys
+from copy import copy
+import re
 
 import yum
 import yum.config
 import yum.Errors
 import yum.plugins
+import warnings
 
+from urlgrabber.grabber import URLGrabError
 from yum.yumRepo import YumRepository
+from yum import logginglevels
+import logging
 
 
 __all__ = ['requires_api_version', 'plugin_type', 'CONDUIT',
@@ -42,12 +47,21 @@ __all__ = ['requires_api_version', 'plugin_type', 'CONDUIT',
 requires_api_version = '2.5'
 plugin_type = yum.plugins.TYPE_CORE
 CONDUIT = None
+DEFAULT_DELAY = 3
+DEFAULT_BACKOFF = 2
+BUFFER_SIZE = 1024*1024*32
+UNSUPPORTED_ATTRIBUTES = ['mirrorlist', 'proxy']
 
+verbose_logger = logging.getLogger("yum.verbose.Repos")
+logger = logging.getLogger("yum.Repos")
 
 def config_hook(conduit):
     yum.config.RepoConf.s3_enabled = yum.config.BoolOption(False)
     yum.config.RepoConf.key_id = yum.config.Option()
     yum.config.RepoConf.secret_key = yum.config.Option()
+    # Usually this is taken care with urlgrabber but not here
+    yum.config.RepoConf.backoff = yum.config.Option()
+    yum.config.RepoConf.delay = yum.config.Option()
 
 
 def prereposetup_hook(conduit):
@@ -59,24 +73,45 @@ def prereposetup_hook(conduit):
         if isinstance(repo, YumRepository) and repo.s3_enabled:
             new_repo = S3Repository(repo.id, repo.baseurl)
             new_repo.name = repo.name
-            # new_repo.baseurl = repo.baseurl
-            new_repo.mirrorlist = repo.mirrorlist
             new_repo.basecachedir = repo.basecachedir
             new_repo.gpgcheck = repo.gpgcheck
             new_repo.gpgkey = repo.gpgkey
             new_repo.key_id = repo.key_id
             new_repo.secret_key = repo.secret_key
-            new_repo.proxy = repo.proxy
             new_repo.enablegroups = repo.enablegroups
-            if hasattr(repo, 'priority'):
-                new_repo.priority = repo.priority
+
+            # unsupported attributes
+            for attr in UNSUPPORTED_ATTRIBUTES:
+                if getattr(repo, attr):
+                    msg = "%s: Unsupported attribute: %s." % (__file__, attr)
+                    raise yum.plugins.PluginYumExit(msg)
+
+            # handling HTTP errors
+            new_repo.retries = repo.retries
+            new_repo.backoff = repo.backoff
+            new_repo.delay = repo.delay
+
             if hasattr(repo, 'base_persistdir'):
                 new_repo.base_persistdir = repo.base_persistdir
             if hasattr(repo, 'metadata_expire'):
                 new_repo.metadata_expire = repo.metadata_expire
             if hasattr(repo, 'skip_if_unavailable'):
                 new_repo.skip_if_unavailable = repo.skip_if_unavailable
+            if hasattr(repo, 'mdpolicy'):
+                new_repo.mdpolicy = repo.mdpolicy
 
+            # Per repo cache is implemented in some forks
+            # eg. yum-3.4.3-137.51.amzn1.noarch.
+            # It never made it mainstream:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1001072
+            if hasattr(repo, 'keepcache'):
+                new_repo.keepcache = repo.keepcache
+
+            # Requires priority plugin
+            if hasattr(repo, 'priority'):
+                new_repo.priority = repo.priority
+
+            verbose_logger.log(logginglevels.DEBUG_2, new_repo.dump())
             repos.delete(repo.id)
             repos.add(new_repo)
 
@@ -106,29 +141,81 @@ class S3Repository(YumRepository):
                 self.grabber.get_credentials()
         return self.grabber
 
+    def _getFile(self, **kwargs):
+        """
+            Override _getFile from yumRepo to ignore non-relative urls.
+        """
+        # Override `url` property of file so `yum` uses rel. paths `relative`
+        # Baseurl, specified in `yum.repos.d/somerepo.repo` will be used to
+        # form all urls instead of absolute paths.
+        # The intent is to use a single retriever for all resources originating
+        # from a single repository.
+        # The helpful side effect here is that if we specify an `https://` in
+        # baseurl in `yum.repos.d`, then that `https` setting will be passed
+        # through metadata and package downloads.
+        # On the downside, you cannot specify an alternate server for
+        # downloading packages.
+        # LOC: http://yum.baseurl.org/gitweb?p=yum.git;a=blob;f=yum/yumRepo.py;h=f7257d1c1ccb743fbc2ffb5611596698137387b5;hb=HEAD#l741
+        # sample sequence of requests:
+        # metadata (repomd.xml) => sqlite DBs => package
+        # {'text': 'packages','relative': 'repodata/repomd.xml',
+        # 'local': '/var/cache/yum/x86_64/2014.03/packages/repomdEd8Yujtmp.xml', 'size': 102400}
+        # {'text': 'packages/primary_db', 'reget': None,
+        # 'relative': 'repodata/primary.1456367509.sqlite.bz2',
+        # 'local': '/var/cache/yum/x86_64/2014.03/packages/primary.1456367509.sqlite.bz2', 'size': None}
+        # {'url': 'http://packages.s3.amazonaws.com/cent6',
+        # 'text': 'sysdig-0.5.0-x86_64.rpm','relative': 'RPMS/sysdig-0.5.0-x86_64.rpm',
+        # 'local': '/var/cache/yum/x86_64/2014.03/packages/packages/sysdig-0.5.0-x86_64.rpm', 'size': 1764624}
+        #
+        # package has a url property that allow downloads from sources that are
+        # hosted on other servers than metadata. Different urlgrabber is
+        # instantiated.
+        # Overriding url property enforces usage of relative urls and thus
+        # single urlgrabber is used.
+
+        # Convert all package urls to relative
+        if kwargs.get('url'):
+            kwargs['url'] = None
+
+        return super(S3Repository, self)._getFile(**kwargs)
+
 
 class S3Grabber(object):
 
     def __init__(self, repo):
-        """Initialize file grabber.
-        Note: currently supports only single repo.baseurl. So in case of a list
-              only the first item will be used.
         """
-        if isinstance(repo, basestring):
-            self.baseurl = repo
+        Initialize file grabber.
+        Note: Currently supports only single repo.baseurl.
+              Only the first item of the list will be used.
+        """
+
+        if len(repo.baseurl) != 1:
+            msg = "%s: repository '%s' must" % (__file__, repo.id, )
+            msg += 'have only one baseurl value'
+            raise yum.plugins.PluginYumExit(msg)
         else:
-            if len(repo.baseurl) != 1:
-                raise yum.plugins.PluginYumExit("s3iam: repository '%s' "
-                                                "must have only one "
-                                                "'baseurl' value" % repo.id)
-            else:
-                self.baseurl = repo.baseurl[0]
+            self.baseurl = repo.baseurl[0]
+
+        self.retries = repo.retries
+
+        if repo.backoff is None:
+            self.backoff = DEFAULT_BACKOFF
+        else:
+            self.backoff = repo.backoff
+
+        if repo.delay is None:
+            self.delay = DEFAULT_DELAY
+        else:
+            self.delay = repo.delay
+
         # Ensure urljoin doesn't ignore base path:
         if not self.baseurl.endswith('/'):
             self.baseurl += '/'
 
     def get_role(self):
-        """Read IAM role from AWS metadata store."""
+        """
+        Read IAM role from AWS metadata store.
+        """
         request = urllib2.Request(
             urlparse.urljoin(
                 "http://169.254.169.254",
@@ -148,17 +235,20 @@ class S3Grabber(object):
         Note: This method should be explicitly called after constructing new
               object, as in 'explicit is better than implicit'.
         """
-        request = urllib2.Request(
+        url = urlparse.urljoin(
             urlparse.urljoin(
-                urlparse.urljoin(
-                    "http://169.254.169.254/",
-                    "latest/meta-data/iam/security-credentials/",
-                ), self.iamrole))
+                "http://169.254.169.254/",
+                "latest/meta-data/iam/security-credentials/",
+            ), self.iamrole)
 
+        request = urllib2.Request(url)
         response = None
+
         try:
             response = urllib2.urlopen(request)
             data = json.loads(response.read())
+            verbose_logger.log(logginglevels.DEBUG_2,
+                               "Successfully retrieved IAM credentials")
         finally:
             if response:
                 response.close()
@@ -184,34 +274,58 @@ class S3Grabber(object):
         return request
 
     def urlgrab(self, url, filename=None, **kwargs):
-        """urlgrab(url) copy the file to the local filesystem."""
-        request = self._request(url)
+        """
+        grab the file at <url> and make a local copy at <filename>
+        If filename is None, the basename of the url is used.
+        """
+
+        parts = urlparse.urlparse(url)
+        (scheme, host, path, parm, query, frag) = parts
         if filename is None:
-            filename = request.get_selector()
-            if filename.startswith('/'):
-                filename = filename[1:]
+            filename = os.path.basename(urllib.unquote(path))
 
         response = None
-        try:
-            out = open(filename, 'w+')
-            response = urllib2.urlopen(request)
-            buff = response.read(8192)
-            while buff:
-                out.write(buff)
-                buff = response.read(8192)
-        except urllib2.HTTPError, e:
-            # Wrap exception as URLGrabError so that YumRepository catches it
-            from urlgrabber.grabber import URLGrabError
-            new_e = URLGrabError(14, '%s on %s' % (e, url))
-            new_e.code = e.code
-            new_e.exception = e
-            new_e.url = url
-            raise new_e
-        finally:
-            if response:
-                response.close()
-            out.close()
+        retries = copy(self.retries)
+        delay = self.delay
 
+        out = open(filename, 'w+')
+        while True:
+            try:
+                request = self._request(url)
+                logger.log(logginglevels.DEBUG_2, "GET: %s" % url)
+                response = urllib2.urlopen(request)
+                buff = response.read(BUFFER_SIZE)
+                while buff:
+                    out.write(buff)
+                    buff = response.read(BUFFER_SIZE)
+
+            except urllib2.HTTPError, e:
+                if retries > 0:
+                    retries -= 1
+                    msg = "%s, Retry attempt %d in %d seconds..." % \
+                        (str(e), self.retries-retries, delay)
+                    verbose_logger.log(logginglevels.DEBUG_2, msg)
+                    time.sleep(delay)
+                    delay *= self.backoff
+                else:
+                    # Wrap exception as URLGrabError so that YumRepository
+                    # catches it
+                    msg = '%s on %s tried %s time(s)' % \
+                        (e, url, self.retries)
+
+                    new_e = URLGrabError(14, msg)
+                    new_e.code = e.code
+                    new_e.exception = e
+                    new_e.url = url
+                    raise new_e
+
+            finally:
+                if response:
+                    response.close()
+                    break
+
+            out.close()
+            sys.stdout.flush()
         return filename
 
     def urlopen(self, url, **kwargs):
@@ -226,28 +340,27 @@ class S3Grabber(object):
         """Attach a valid S3 signature to request.
         request - instance of Request
         """
-        date = time.strftime("%a, %d %b %Y %H:%M:%S GMT", timeval or time.gmtime())
+        date = time.strftime("%a, %d %b %Y %H:%M:%S GMT",
+                             timeval or time.gmtime())
         request.add_header('Date', date)
         host = request.get_host()
 
-        # TODO: bucket name finding is ugly, I should find a way to support
-        # both naming conventions: http://bucket.s3.amazonaws.com/ and
-        # http://s3.amazonaws.com/bucket/
         try:
-            pos = host.find(".s3")
-            assert pos != -1
-            bucket = host[:pos]
-        except AssertionError:
-            raise yum.plugins.PluginYumExit(
-                "s3iam: baseurl hostname should be in format: "
-                "'<bucket>.s3<aws-region>.amazonaws.com'; "
-                "found '%s'" % host)
+            resource = get_resource(request.get_full_url())
+        except RuntimeError, e:
+            logger.log(logginglevels.DEBUG_4, e.msg)
+            msg = "Unable to resolve bucket from: %s." % request.get_full_url()
+            msg += "Please use http(s)://bucket.s3.amazonaws.com/path or "
+            msg += "http(s)://s3.amazonaws.com/bucket/path as baseurl"
+            raise yum.plugins.PluginYumExit(msg)
 
-        resource = "/%s%s" % (bucket, request.get_selector(), )
+        # For dynamic IAM credentials token is retrieved from metadata endpoint
+        # It's is not required for static IAM credentials
         if self.token:
             amz_headers = 'x-amz-security-token:%s\n' % self.token
         else:
             amz_headers = ''
+
         sigstring = ("%(method)s\n\n\n%(date)s\n"
                      "%(canon_amzn_headers)s%(canon_amzn_resource)s") % ({
                          'method': request.get_method(),
@@ -260,3 +373,45 @@ class S3Grabber(object):
             hashlib.sha1).digest()
         signature = digest.encode('base64')
         return signature.strip()
+
+
+def get_hostname_embedded_bucket(url):
+    """
+        Extracts bucket from the URL
+    """
+    # find rightmost s3.*amazonaws.com and strip it to get bucket
+    parsed = urlparse.urlparse(url)
+    bucket = None
+    match = re.search(r'(\.[\w-]+?\.amazonaws\.com)',
+                      parsed.netloc)
+    if match:
+        # strip s3.*amazonaws.com and return bucket
+        bucket = parsed.netloc.replace(match.group(0), '')
+
+    return bucket
+
+
+def get_resource(url):
+    """
+        Extracts resource information from the URL
+    """
+    hostname_embedded_bucket = get_hostname_embedded_bucket(url)
+    parsed = urlparse.urlparse(url)
+
+    if hostname_embedded_bucket:
+        verbose_logger.log(logginglevels.DEBUG_4,
+                           "Found bucket:%s" % hostname_embedded_bucket)
+        result = parsed.path
+        if not result:
+            result = "/"
+    else:
+        if parsed.path.count('/') < 2:
+            verbose_logger.log(logginglevels.DEBUG_4,
+                               "Found resource: %s" % parsed.path)
+            # http://s3.amazonaws.com/path is invalid since it does not have
+            # bucket in the path
+            msg = "Could not determine valid s3 bucket %s" % url
+            raise RuntimeError(msg)
+        result = parsed.path
+
+    return result

--- a/tests.py
+++ b/tests.py
@@ -22,114 +22,410 @@ import urllib2
 import unittest
 import rpm
 import yum
-import createrepo
-sys.path.append('.')
+
+sys.path.append('/usr/lib/yum-plugins')
 import s3iam
 
 
-PACKAGE_NAME = 'yum-plugin-s3-iam'
-RPM_DIR = rpm.expandMacro('%_rpmdir')
-try:
-    RPM_FILE = glob.glob(os.path.join(RPM_DIR, 'noarch', PACKAGE_NAME + '*.rpm'))[0]
-except IndexError:
-    RPM_FILE = None
-
-
+# Allows supressing messages from MetaDataGenerator
 class MDCallback(object):
     def log(self, msg):
+        pass
+    def errorlog(self, msg):
         pass
 
 
 class YumTestCase(unittest.TestCase):
 
-    baseurl = 'http://test.s3.amazonaws.com/noarch/'
+    MOCK_HOST_BASEURL = 'http://test.s3.amazonaws.com/noarch/'
+    MOCK_PATH_BASEURL = 'http://s3.amazonaws.com/noarch/test/'
+    MOCK_BASEURLS = [MOCK_HOST_BASEURL, MOCK_PATH_BASEURL]
 
-    def _createrepo(self):
+    MOCK_BROKEN_BASEURL = 'http://broken.s3.amazonaws.com/test'
+
+    def _createrepo(self, package_name):
+        err_msg = None
+        try:
+            import createrepo
+            rpm_dir = rpm.expandMacro('%_rpmdir')
+            rpm_file = glob.glob(os.path.join(rpm_dir,
+                                              'noarch',
+                                              package_name + '*.rpm'
+                                              ))[0]
+            shutil.copyfile(rpm_file, os.path.join(self.tmpdir, 's3iam.rpm'))
+
+        except IndexError:
+            err_msg = 'Skipping: Createrepo not found!'
+
+        except ImportError:
+            err_msg = 'Skipping:', 'RPM file %s not found' % package_name
+
+        if err_msg:
+            print >> sys.stderr, err_msg
+            return
+
         mdconf = createrepo.MetaDataConfig()
         mdconf.directory = self.tmpdir
         mdgen = createrepo.MetaDataGenerator(mdconf, MDCallback())
         mdgen.doPkgMetadata()
         mdgen.doRepoMetadata()
         mdgen.doFinalMove()
+        return mdgen
 
     def _mock_urlopen(self, url):
+        """ Provides stub responses for urlopen based on the URL """
         if hasattr(url, 'get_full_url'):
             url = url.get_full_url()
-        if 'security-credentials' in url:
-            return StringIO.StringIO('{"AccessKeyId":"k", "SecretAccessKey":"x", "Token": "t"}')
-        else:
-            if 'broken' in url:
-                raise urllib2.HTTPError(url, 403, 'Forbidden', None, None)
-            # return files from local repo created with _createrepo
-            assert url.startswith(self.baseurl)
-            return open(os.path.join(self.tmpdir, url[len(self.baseurl):]))
 
-    def _init_yum(self, baseurl=None, **kwargs):
-        cwd = os.getcwd()
-        yum.config.StartupConf.pluginpath =\
-            yum.config.StartupConf.pluginconfpath = yum.config.ListOption([cwd])
+        if 'security-credentials' in url:
+            pload = '{"AccessKeyId":"k", "SecretAccessKey":"x", "Token":"t"}'
+            return StringIO.StringIO(pload)
+
+        if 'broken' in url:
+            raise urllib2.HTTPError(url, 403, 'Forbidden', None, None)
+
+        # return files from local repo created with _createrepo
+        assert any([url.startswith(u) for u in self.MOCK_BASEURLS])
+        for bu in self.MOCK_BASEURLS:
+            if url.startswith(bu):
+                return open(os.path.join(self.tmpdir, url[len(bu):]))
+
+    def _init_yum(self):
+        # this allows both testing where the plugin, conf and test
+        # are spread among different paths
+        paths = [os.getcwd(),
+                 '/usr/lib/yum-plugins',
+                 '/etc/yum/pluginconf.d']
+        yum.config.StartupConf.pluginpath = yum.config.ListOption(paths)
+        yum.config.StartupConf.pluginconfpath = yum.config.ListOption(paths)
         yumbase = yum.YumBase()
         yumbase.preconf.disabled_plugins = '*'
         yumbase.preconf.enabled_plugins = ['s3iam']
-        yumbase.preconf.debuglevel = 0
+        yumbase.preconf.debuglevel = 1
         yumbase.conf.cachedir = os.path.join(self.tmpdir, '_cache')
         yumbase.repos.disableRepo('*')
-        yumbase.add_enable_repo('s3test', [baseurl or self.baseurl],
-                                s3_enabled=True, _async=True, **kwargs)
+
         return yumbase
+
+    def _add_enable_s3_repo(self, name, **kwargs):
+        self.yumbase.add_enable_repo(name, s3_enabled=True, **kwargs)
+        self.yumbase.repos.doSetup(thisrepo=name)
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        # Set up urlopen mock:
+        # Set up urlopen mock
         urllib2.urlopen, urllib2.urlopen_ = self._mock_urlopen, urllib2.urlopen
+        self.yumbase = self._init_yum()
+        # Set up mock logger
+        s3iam.verbose_logger, s3iam.verbose_logger_ = CountingLogger, s3iam.verbose_logger
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
         urllib2.urlopen = urllib2.urlopen_
+        CountingLogger.reset()
+        s3iam.verbose_logger = s3iam.verbose_logger_
 
-    # @unittest.skipIf(RPM_FILE is None, 'Rpm file required')
-    def test_yum_available(self):
-        if not RPM_FILE:
-            print >>sys.stderr, 'Skipping:', 'Rpm file required'
+    def test_repo_list_returns_valid_package_with_host_baseurl(self):
+        """
+            Make requests with s3 plugin to a stubbed repo in /tmp
+        """
+
+        # create repository with the one rpm package
+        # _mock_urlopen will use that metadata
+        package_name = 'yum-plugin-s3-iam'
+        if not self._createrepo(package_name=package_name):
             return
-        # copy rpm file to tmpdir and create repodata
-        shutil.copyfile(RPM_FILE, os.path.join(self.tmpdir, 's3iam.rpm'))
-        self._createrepo()
 
-        yumbase = self._init_yum()
-        available = yumbase.doPackageLists().available
-        self.assertEqual([p.name for p in available], [PACKAGE_NAME])
+        self._add_enable_s3_repo('s3test', baseurl=self.MOCK_PATH_BASEURL)
+        available = self.yumbase.doPackageLists().available
+        self.assertEqual([p.name for p in available], [package_name])
 
-    def test_repo_unavailable(self):
-        self._createrepo()
+    def test_repo_list_returns_valid_package_with_path_baseurl(self):
+        """
+            Make requests with s3 plugin to a stubbed repo in /tmp
+        """
 
-        # Throws RepoError exception
-        yumbase = self._init_yum(
+        # create repository with the one rpm package
+        # _mock_urlopen will use that metadata
+        package_name = 'yum-plugin-s3-iam'
+        if not self._createrepo(package_name=package_name):
+            return
+
+        self._add_enable_s3_repo('s3test', baseurl=self.MOCK_PATH_BASEURL)
+        available = self.yumbase.doPackageLists().available
+        self.assertEqual([p.name for p in available], [package_name])
+
+    def test_repo_unavailable_throws_exception_without_retry(self):
+        """
+            Setting retry to < 1 will cause no retries.
+            Currently infinite retry with -1 is not supported.
+            If you would like to schedule infinite-like time please set
+            big enough number of retries
+        """
+        self._add_enable_s3_repo(
+            's3test',
             baseurl='http://broken.s3.amazonaws.com',
+            retries=0,
             skip_if_unavailable=False,
         )
-        self.assertRaises(yum.Errors.RepoError,
-                          lambda: yumbase.doPackageLists().available)
+        self.assertRaises(yum.Errors.RepoError, self.yumbase.doPackageLists)
 
+    def test_repo_unavailable_throws_exception_with_retry(self):
+        """
+            Test retry logic without waiting default number of retries
+        """
+
+        retries = 3
+        backoff = 1
+        delay = 1
+
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL,
+            retries=retries,
+            delay=delay,
+            backoff=backoff,
+            skip_if_unavailable=False,
+        )
+
+        try:
+            self.yumbase.doPackageLists()
+        except yum.Errors.RepoError, e:
+            pass
+
+        s3testrepo = [r for r in self.yumbase.repos.listEnabled()
+                      if r.name == 's3test'][0]
+        self.assertEqual(s3testrepo.retries, retries)
+        self.assertEqual(s3testrepo.backoff, backoff)
+        self.assertEqual(s3testrepo.delay, delay)
+
+        # Retry message: 8_HTTP Error 403: Forbidden, Retry attempt
+        retry_msgs = [m for m in s3iam.verbose_logger.counter.keys() if
+                      m.find('Forbidden, Retry attempt') > 0]
+        self.assertEqual(len(retry_msgs), retries)
+
+    def test_repo_unavailable_skips_quietly(self):
         # No exception when skip_if_unavailable
-        yumbase = self._init_yum(
-            baseurl='http://broken.s3.amazonaws.com',
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL,
+            retries=0,
             skip_if_unavailable=True,
         )
-        yumbase.doPackageLists().available
+
+        self.assertEqual(self.yumbase.doPackageLists().available, [])
+
+    def test_repo_basic_options(self):
+        skip_if_unavailable = True
+
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL,
+            skip_if_unavailable=skip_if_unavailable,
+        )
+
+        s3testrepo = [r for r in self.yumbase.repos.listEnabled()
+                      if r.name == 's3test'][0]
+        self.assertEquals(s3testrepo.baseurl, [self.MOCK_BROKEN_BASEURL])
+        self.assertEquals(s3testrepo.skip_if_unavailable, skip_if_unavailable)
+
+    def test_repo_disable_on_runtime_should_omit(self):
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL,
+        )
+
+        repos = self.yumbase._getRepos()
+
+        # simulate run-time disable with --disablerepo=s3test
+        repos.disableRepo('s3test')
+        # s3 repo should have been the only one; now it should not be present
+        self.assertEquals(repos.listEnabled(), [])
+
+    def test_repo_default_attributes(self):
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL
+        )
+
+        s3testrepo = [r for r in self.yumbase.repos.listEnabled()
+                      if r.name == 's3test'][0]
+
+        self.assertEquals(s3testrepo.retries, 10)
+        self.assertEquals(s3testrepo.enablegroups, True)
+        self.assertEquals(s3testrepo.metadata_expire, 0)
+        self.assertEquals(s3testrepo.gpgcheck, True)
+
+    def test_repo_unsupported_attribute_proxy(self):
+        self.assertRaises(yum.plugins.PluginYumExit,
+                          lambda: self._add_enable_s3_repo(
+                                    's3test',
+                                    baseurl=self.MOCK_BROKEN_BASEURL,
+                                    proxy='http://proxy.com:8080/invalid'
+                          ))
+
+    def test_repo_unsupported_attribute_mirrorlist(self):
+        self.assertRaises(yum.plugins.PluginYumExit,
+                          lambda: self._add_enable_s3_repo(
+                                    's3test',
+                                    baseurl=self.MOCK_BROKEN_BASEURL,
+                                    mirrorlist='http://somewhere.com/invalid'
+                          ))
+
+    def skipIfNoKeepcache(f):
+        """
+        Decorator to skip tests for keepcache on not supported yum
+        """
+        if hasattr(yum.config.RepoConf, 'keepcache'):
+            return f
+        return lambda self: 0
+
+    @skipIfNoKeepcache
+    def test_repo_inherited_attributes(self):
+        self._add_enable_s3_repo(
+            's3test',
+            baseurl=self.MOCK_BROKEN_BASEURL
+        )
+
+        s3testrepo = [r for r in self.yumbase.repos.listEnabled()
+                      if r.name == 's3test'][0]
+
+        self.assertEquals(s3testrepo.keepcache, True)
+
+
+class UtilsTest(unittest.TestCase):
+    def test_get_resource_with_bucket_host_url(self):
+        url = "https://bucket.s3-external-1.amazonaws.com/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), 'bucket')
+        self.assertEquals(s3iam.get_resource(url), "/path")
+
+    def test_get_resource_with_bucket_host_url_double_s3(self):
+        url = "https://s3bucket.s3-external-1.amazonaws.com/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), 's3bucket')
+        self.assertEquals(s3iam.get_resource(url), "/path")
+
+    def test_get_resource_with_bucket_host_url_with_dots(self):
+        url = "https://s3bucket.with.dots.s3-external-1.amazonaws.com/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url),
+                          's3bucket.with.dots')
+        self.assertEquals(s3iam.get_resource(url), "/path")
+
+    def test_get_resource_with_bucket_host_url_regional(self):
+        url = "https://bucket.s3-east-1.amazonaws.com/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), 'bucket')
+        self.assertEquals(s3iam.get_resource(url), "/path")
+
+    def test_get_resource_with_bucket_host_naked_bucket(self):
+        url = "http://bucket.s3.amazonaws.com/"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), 'bucket')
+        self.assertEquals(s3iam.get_resource(url), "/")
+
+    def test_get_resource_with_bucket_host_naked_bucket(self):
+        url = "http://bucket.s3.amazonaws.com"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), 'bucket')
+        self.assertEquals(s3iam.get_resource(url), "/")
+
+    def test_get_resource_with_bucket_path_url(self):
+        url = "https://s3.amazonaws.com/bucket/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertEquals(s3iam.get_resource(url), "/bucket/path")
+
+    def test_get_resource_with_bucket_path_url_double_bucket(self):
+        url = "https://s3.amazonaws.com/bucket/bucket/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertEquals(s3iam.get_resource(url), "/bucket/bucket/path")
+
+    def test_get_resource_with_bucket_path_url_ending_with_slash(self):
+        url = "https://s3.amazonaws.com/bucket/bucket/path/"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertEquals(s3iam.get_resource(url), "/bucket/bucket/path")
+
+    def test_get_resource_with_bucket_path_url_ending_with_slash(self):
+        url = "https://s3.amazonaws.com/bucket/"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertEquals(s3iam.get_resource(url), "/bucket/")
+
+    def test_get_resource_with_bucket_path_url_no_bucket(self):
+        url = "https://s3.amazonaws.com/path"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertRaises(RuntimeError, s3iam.get_resource, url)
+
+    def test_get_resource_with_bucket_path_url_no_path(self):
+        url = "https://s3.amazonaws.com"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertRaises(RuntimeError, s3iam.get_resource, url)
+
+    def test_get_resource_with_bucket_path_url_no_path_slash(self):
+        url = "https://s3.amazonaws.com/"
+        self.assertEquals(s3iam.get_hostname_embedded_bucket(url), None)
+        self.assertRaises(RuntimeError, s3iam.get_resource, url)
+
+
+class CountingLogger(object):
+    """
+    Logger with message counter
+    """
+    counter = {}
+
+    @classmethod
+    def log(cls, level, message):
+        key = "%s_%s" % (level, message,)
+        if cls.counter.get(key):
+            cls.counter[key] += 1
+        else:
+            cls.counter[key] = 1
+
+    @classmethod
+    def reset(cls):
+        cls.counter = {}
+
+
+class Repo(object):
+    """
+    Fake Repository
+    Very loosely based on yum.yumRepos.YumRepository
+    """
+    def __init__(self, repoid):
+        self.baseurl = []
+        self.id = repoid
+
+    def __getattr__(self, name):
+        """ default arguments handler """
+        return None
+
+    def baseurlAdd(self, baseurl):
+        """
+        baseurl is normally setup from mirrorlist
+        S3 plugin does not handle mirrorlist
+        """
+        self.baseurl.append(baseurl)
 
 
 class S3GrabberTest(unittest.TestCase):
 
-    def test_example_sign(self):
-        """Test with example data"""
-        grabber = s3iam.S3Grabber("http://johnsmith.s3.amazonaws.com/")
+    def test_sign_example_url(self):
+        """
+        Verify the signing alghoritm
+        """
+        fakerepo = Repo('fakerepo')
+        fakerepo.baseurlAdd("http://fakerepo.s3.amazonaws.com/")
+        grabber = s3iam.S3Grabber(fakerepo)
         grabber.access_key = "AKIAIOSFODNN7EXAMPLE"
         grabber.secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         grabber.token = 'None'
         request = grabber._request("photos/puppy.jpg")
-        signature = grabber.sign(request, timeval=(2013, 1, 1, 0, 0, 0, 0, 0, 0))
-        self.assertEqual(signature.strip(), "g28R8sx2k7a5lW/9jMfCNfnMHjc=")
+        signature = grabber.sign(request,
+                                 timeval=(2013, 1, 1, 0, 0, 0, 0, 0, 0))
+        self.assertEqual(signature.strip(), "WMjyjyTNSM6359fP19vZtbxjykY=")
+
+    def test_init_with_many_baseurl_should_raise_error(self):
+        """
+        Only 1 baseurl is currently supported
+        """
+        fakerepo = Repo('fakerepo')
+        fakerepo.baseurlAdd("http://bucket1.s3.amazonaws.com/")
+        fakerepo.baseurlAdd("http://bucket2.s3.amazonaws.com/")
+        self.assertRaises(yum.plugins.PluginYumExit, s3iam.S3Grabber, fakerepo)
 
 
 if __name__ == '__main__':

--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -37,8 +37,8 @@ rm -rf ${RPM_BUILD_ROOT}
 /usr/lib/yum-plugins/s3iam.py*
 
 %changelog
-* Mon Sep 21 2015 Mathias Brossard <mathias@brossard.org> 1.0.1-1
-Fix for trailing line-feed on signature
+* Tue Nov 03 2015 Mathias Brossard <mathias@brossard.org> 1.0.2-1
+Fix for trailing line-feed on signature on newer python 2.7
 
 * Fri May 31 2013 Matt Jamison <matt@mattjamison.com> 1.0-1
 Initial packaging


### PR DESCRIPTION
I've made certain improvements to the yums3iam plugin and wanted to share them back.
I've squashed all the commits into 1 big but can include individual ones if you think there is a benefit in tracking individual changes. They're highly correlated so I felt this is actually an unified change but up for discussion.

Added:
- more test coverage and various fixes
- add test for path vs host bucket notation
- add helper methods and tests
- to be runnable from any environment
- support people who like weird names
- more path resolving
- replace stdout couting with counting logger
- getFile info
- resource url signing improvements
- unsupported attributes; raise on unsupported attributes
- updated comments
- lower verbosity

I was focusing on making the testability possible thus the docker container and cent6 and another make target. Tests are pretty self explanatory but I am open to clarify anything reg the code.

The code is primarily tested agains the cent6/yum26 but it has also been tested with a fork of yum included in the amazon-linux (with python26 and python27). Have not tested with any other rpm-based platforms. I've tried to pick the common denominator (python26 so the tests are pretty crude since I unittest module had limited capability back then :))
