### PR TITLE
Added support for cross account authorisation. This allows the plugin...

### DIFF
--- a/s3iam.conf
+++ b/s3iam.conf
@@ -17,3 +17,6 @@
 ;
 [main]
 enabled=1
+
+; provide a delegated role arn to support a bucket in a different account
+;delegated_role=arn:aws:iam::XXXXXXXXXXXX:role/some-role

--- a/s3iam.py
+++ b/s3iam.py
@@ -104,7 +104,7 @@ class S3Repository(YumRepository):
             if self.key_id and self.secret_key:
                 self.grabber.set_credentials(self.key_id, self.secret_key)
             elif self.delegated_role:
-                self.grabber.get_region()
+                self.grabber.get_instance_region()
                 self.grabber.get_delegated_role_credentials(self.delegated_role)
             else:
                 self.grabber.get_role()
@@ -190,7 +190,7 @@ class S3Grabber(object):
         self.secret_key = assumed_role.credentials.secret_key
         self.token = assumed_role.credentials.session_token
 
-    def get_region(self):
+    def get_instance_region(self):
         """Read region from AWS metadata store."""
         request = urllib2.Request(
             urlparse.urljoin(

--- a/s3iam.py
+++ b/s3iam.py
@@ -33,8 +33,6 @@ import yum.config
 import yum.Errors
 import yum.plugins
 
-import boto.sts
-
 from yum.yumRepo import YumRepository
 
 
@@ -183,6 +181,8 @@ class S3Grabber(object):
         Note: This method should be explicitly called after constructing new
               object, as in 'explicit is better than implicit'.
         """
+        import boto.sts
+
         sts_conn = boto.sts.connect_to_region(self.region)
         assumed_role = sts_conn.assume_role(delegated_role, 'yum')
 


### PR DESCRIPTION
… to work with a bucket in a different account by using a delegated role provided in the plugin config.

Wanted to make this work for a bucket in a separate account so that the repo did not need to be replicated. Works by using the delegated role arn (provided via config) to retrieve the creds from STS.

It does introduce a dependency on boto which may not be considered desirable.
Also introduces a get_region method which may conflict slightly with what is going on in the v4_scheme  branches.