### PR TITLE
workaround for CertificateError for dotted bucket

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import ssl
+if hasattr(ssl, '_create_unverified_context'):
+    ssl._create_default_https_context = ssl._create_unverified_context
 import urllib2
 import urlparse
 import datetime


### PR DESCRIPTION
It's a bit ugly fix, but at least it fixes the issue.
It's also good to have it for reference now.

https://github.com/boto/boto/issues/2836