### PR TITLE
Fix http[s]://s3.amazonaws.com/<bucket> URLs

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -80,7 +80,7 @@ def parse_url(url):
     # http[s]://s3.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
     if m:
-        return (m.group(2), 'us-east-1', m.group(3))
+        return (m.group(2), None, m.group(3))
 
     # http[s]://s3.cn-north-1.amazonaws.com.cn/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]cn-north-1[.]amazonaws[.]com[.]cn/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)

--- a/tests.py
+++ b/tests.py
@@ -154,7 +154,7 @@ class UrlTests(unittest.TestCase):
 
         (b, r, p) = s3iam.parse_url('https://s3.amazonaws.com/bar/path')
         self.assertEqual(b, 'bar')
-        self.assertEqual(r, 'us-east-1')
+        self.assertEqual(r, None)
         self.assertEqual(p, '/path')
 
         (b, r, p) = s3iam.parse_url('https://s3-us-west-1.amazonaws.com/bar/path')


### PR DESCRIPTION
The parse_url function returns 'us-east-1' for http[s]://s3.amazonaws.com/<bucket> URLs, while it returns None for http[s]://<bucket>.s3.amazonaws.com/ URLs. This causes the plugin to try to retrieve https://s3-us-east-1.amazonaws.com/<bucket>, but that host does not exist.

Changing the case to return None to match the other fixes.