### PR TITLE
Proxy support

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,4 @@
 FROM centos:latest
-MAINTAINER GPP DevOps <SBG-PDGPP-DevOps@intuit.com>
 
 RUN mkdir -p /app;\
     yum install -y createrepo make rpm-build epel-release;\

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM centos:latest
+MAINTAINER GPP DevOps <SBG-PDGPP-DevOps@intuit.com>
+
+RUN mkdir -p /app;\
+    yum install -y createrepo make rpm-build epel-release;\
+    yum install -y python2-mock
+ADD . /app
+WORKDIR /app
+ENTRYPOINT ["/usr/bin/make"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Currently the plugin does not support:
 
 Use `make test` to run some simple tests.
 
+### Testing with docker compose:
+docker-compose -f docker-compose.tests.yml run yum-s3-iam test
+docker-compose -f docker-compose.tests.yml down --volumes --rmi all
+
 ## License
 
 Apache 2.0 license. See LICENSE.

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  yum-s3-iam:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    image: s3-iam-plugin
+    volumes:
+        - .:/app/
+    working_dir: /app/
+    network_mode: 'bridge'

--- a/s3iam.py
+++ b/s3iam.py
@@ -34,7 +34,7 @@ __author__ = "Julius Seporaitis"
 __email__ = "julius@seporaitis.net"
 __copyright__ = "Copyright 2012, Julius Seporaitis"
 __license__ = "Apache 2.0"
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 __all__ = ['requires_api_version', 'plugin_type', 'CONDUIT',
@@ -48,7 +48,7 @@ DEFAULT_BACKOFF = 2
 BUFFER_SIZE = 1024 * 1024
 OPTIONAL_ATTRIBUTES = ['priority', 'base_persistdir', 'metadata_expire',
                        'skip_if_unavailable', 'keepcache', 'priority']
-UNSUPPORTED_ATTRIBUTES = ['mirrorlist', 'proxy']
+UNSUPPORTED_ATTRIBUTES = ['mirrorlist']
 
 
 def config_hook(conduit):
@@ -161,6 +161,18 @@ class S3Repository(YumRepository):
             if getattr(repo, attr):
                 msg = "%s: Unsupported attribute: %s." % (__file__, attr)
                 raise yum.plugins.PluginYumExit(msg)
+
+        proxy_config = {}
+        if 'https_proxy' in os.environ:
+            proxy_config['https'] = os.environ['https_proxy']
+        if 'http_proxy' in os.environ:
+            proxy_config['http'] = os.environ['http_proxy']
+        if repo.proxy:
+            proxy_config['https'] = proxy_config['http'] = repo.proxy
+        if proxy_config:
+            proxy = urllib2.ProxyHandler(proxy_config)
+            opener = urllib2.build_opener(proxy)
+            urllib2.install_opener(opener)
 
         self.iamrole = None
         self.grabber = None

--- a/tests.py
+++ b/tests.py
@@ -171,24 +171,6 @@ class UrlTests(unittest.TestCase):
 
 class S3RepositoryTest(unittest.TestCase):
 
-#    class FakeRepo:
-#        def __init__(self):
-#            self.baseurl = 'https://s3.cn-north-1.amazonaws.com.cn/bar/path'
-#            self.name = 'test repo'
-#            self.region = 'cn-north-1'
-#            self.basecachedir = ''
-#            self.gpgcheck = False
-#            self.gpgkey = None
-#            self.key_id = None
-#            self.secret_key = None
-#            self.enablegroups = False
-#            self.delegated_role = None
-#            self.retries = 1
-#            self.backoff = None
-#            self.delay = 0
-#            self.mirrorlist = None
-#            self.proxy = None
-
     def setUp(self):
         self.orig_http_proxy = os.environ['http_proxy'] if 'http_proxy' in os.environ else None
         os.environ['https_proxy'] = 'http://https_proxy_host:https_proxy_port'

--- a/tests.py
+++ b/tests.py
@@ -25,6 +25,7 @@ import yum
 import createrepo
 sys.path.append('.')
 import s3iam
+from mock import patch, ANY, MagicMock
 
 
 PACKAGE_NAME = 'yum-plugin-s3-iam'
@@ -166,6 +167,80 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(b, 'bar')
         self.assertEqual(r, 'cn-north-1')
         self.assertEqual(p, '/path')
+
+
+class S3RepositoryTest(unittest.TestCase):
+
+#    class FakeRepo:
+#        def __init__(self):
+#            self.baseurl = 'https://s3.cn-north-1.amazonaws.com.cn/bar/path'
+#            self.name = 'test repo'
+#            self.region = 'cn-north-1'
+#            self.basecachedir = ''
+#            self.gpgcheck = False
+#            self.gpgkey = None
+#            self.key_id = None
+#            self.secret_key = None
+#            self.enablegroups = False
+#            self.delegated_role = None
+#            self.retries = 1
+#            self.backoff = None
+#            self.delay = 0
+#            self.mirrorlist = None
+#            self.proxy = None
+
+    def setUp(self):
+        self.orig_http_proxy = os.environ['http_proxy'] if 'http_proxy' in os.environ else None
+        os.environ['https_proxy'] = 'http://https_proxy_host:https_proxy_port'
+        self.orig_https_proxy = os.environ['https_proxy'] if 'https_proxy' in os.environ else None
+        os.environ['http_proxy'] = 'http://http_proxy_host:http_proxy_port'
+        self.repo = MagicMock(
+            baseurl = 'https://s3.cn-north-1.amazonaws.com.cn/bar/path',
+            name = 'test repo',
+            region = 'cn-north-1',
+            basecachedir = '',
+            gpgcheck = False,
+            gpgkey = None,
+            key_id = None,
+            secret_key = None,
+            enablegroups = False,
+            delegated_role = None,
+            retries = 1,
+            backoff = None,
+            delay = 0,
+            mirrorlist = None,
+            proxy = None
+            )
+
+    def tearDown(self):
+        if self.orig_https_proxy is not None:
+            os.environ['https_proxy'] = self.orig_https_proxy
+        if self.orig_http_proxy is not None:
+            os.environ['http_proxy'] = self.orig_http_proxy
+
+    @patch('s3iam.urllib2')
+    def test_config_proxy_from_env(self, urllib2_mock):
+        s3_repo = s3iam.S3Repository('repo-id', self.repo)
+        urllib2_mock.ProxyHandler.assert_called_once_with({
+            'http':'http://http_proxy_host:http_proxy_port',
+            'https':'http://https_proxy_host:https_proxy_port'
+            })
+        urllib2_mock.build_opener.assert_called_once_with(urllib2_mock.ProxyHandler.return_value)
+        urllib2_mock.install_opener.assert_called_once_with(ANY)
+
+    @patch('s3iam.urllib2')
+    def test_config_proxy_from_yum_conf(self, urllib2_mock):
+        del(os.environ['http_proxy'])
+        del(os.environ['https_proxy'])
+        self.repo.proxy = 'http://same_proxy_for_all:port'
+        s3_repo = s3iam.S3Repository('repo-id', self.repo)
+        urllib2_mock.ProxyHandler.assert_called_once_with({
+            'http':'http://same_proxy_for_all:port',
+            'https':'http://same_proxy_for_all:port'
+            })
+        urllib2_mock.build_opener.assert_called_once_with(urllib2_mock.ProxyHandler.return_value)
+        urllib2_mock.install_opener.assert_called_once_with(ANY)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added proxy support, unit tests and docker configuration in order to be able to run the tests and develop the plugin in any platform.

The current implementation will honor the http_proxy and https_proxy environment variables as well as the proxy config parameter in the repositories.

The repository proxy parameter has precedence over the environment variables.

This will solve the issue #3 