### PR TITLE
fix formatting for 'Testing with docker compose' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ Currently the plugin does not support:
 Use `make test` to run some simple tests.
 
 ### Testing with docker compose:
+
+```
 docker-compose -f docker-compose.tests.yml run yum-s3-iam test
 docker-compose -f docker-compose.tests.yml down --volumes --rmi all
+```
 
 ## License
 


### PR DESCRIPTION
Previously, the two commands appeared on a single line in the standard paragraph font.