### PR TITLE
Set null value for response

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -233,7 +233,8 @@ class S3Grabber(object):
                 "http://169.254.169.254",
                 "/latest/meta-data/iam/security-credentials/"
             ))
-
+        
+        response = None
         try:
             response = urllib2.urlopen(request)
             self.iamrole = (response.read())


### PR DESCRIPTION
On a non-EC2 instance, I'm seeing the following error.  As best I can tell, it happens because the response variable is never set if the EC2 metadata url doesn't exist.  Setting the variable to none appears to resolve the issue.  

```
"/usr/lib/yum-plugins/s3iam.py" 463L, 17040C
        self.token = None
    return base.installPkgs(extcmds, basecmd=basecmd)
  File "/usr/share/yum-cli/cli.py", line 983, in installPkgs
    txmbrs = self.install(pattern=arg)
  File "/usr/lib/python2.7/site-packages/yum/__init__.py", line 4825, in install
    mypkgs = self.pkgSack.returnPackages(patterns=pats,
  File "/usr/lib/python2.7/site-packages/yum/__init__.py", line 1074, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.7/site-packages/yum/__init__.py", line 778, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.7/site-packages/yum/repos.py", line 386, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 227, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 319, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1512, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1698, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1694, in _getRepoXML
    self._loadRepoXML(text=self.ui_id)
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1685, in _loadRepoXML
    return self._groupLoadRepoXML(text, self._mdpolicy2mdtypes())
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1659, in _groupLoadRepoXML
    if self._commonLoadRepoXML(text):
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1479, in _commonLoadRepoXML
    result = self._getFileRepoXML(local, text)
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1256, in _getFileRepoXML
    size=102400) # setting max size as 100K
  File "/usr/lib/python2.7/site-packages/yum/yumRepo.py", line 1022, in _getFile
    result = self.grab.urlgrab(misc.to_utf8(relative), local,
  File "/usr/lib/yum-plugins/s3iam.py", line 194, in grab
    self.grabber.get_role()
  File "/usr/lib/yum-plugins/s3iam.py", line 244, in get_role
    if response:
UnboundLocalError: local variable 'response' referenced before assignment
```