### PR TITLE
use noreplace for config; set default values of name, version, release

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -1,3 +1,9 @@
+%global upstream_name yum-s3-iam
+
+%{?!name:    %global name yum-plugin-s3-iam}
+%{?!version: %global version 1.2.2}
+%{?!release: %global release 2}
+
 Name:      %{name}
 Version:   %{version}
 Release:   %{release}
@@ -18,7 +24,7 @@ Yum package manager plugin for private S3 repositories.
 Uses Amazon IAM & EC2 Roles.
 
 %prep
-%setup -q
+%setup -q -n %{upstream_name}-%{version}
 
 %build
 
@@ -33,10 +39,14 @@ rm -rf ${RPM_BUILD_ROOT}
 %defattr(-,root,root,-)
 %doc s3iam.repo
 %doc LICENSE NOTICE README.md
-%config /etc/yum/pluginconf.d/s3iam.conf
+%config(noreplace) /etc/yum/pluginconf.d/s3iam.conf
 /usr/lib/yum-plugins/s3iam.py*
 
 %changelog
+* Wed Oct 25 2017 Marcin Dulak <Marcin.Dulak@gmail.com> 1.2.2-2
+- use noreplace for config (@marcindulak)
+- set default values of name, version, release (@marcindulak)
+
 * Fri May 05 2017 Mathias Brossard <mathias@brossard.org> 1.2.2-1
 - Handle special value '__none__' for proxy (@andlam)
 


### PR DESCRIPTION
I needed to build an RPM of this plugin, and prefer not to pass any arguments to rpmbuild.

See https://copr.fedorainfracloud.org/coprs/marcindulak/yum-plugin-s3-iam/
If someone prefers to pass name, version, release on the cli it is still possible as before this commit with, e.g.:

```
rpmbuild -bb --define "_sourcedir $PWD" --define 'version 1.2.3' yum-plugin-s3-iam.spec
```

Another necessary change was to use config noreplace for config files, otherwise the config file will be overwritten by a newer RPM version installed.