### PR TITLE
Build .spec file from .spec.in, so .spec file has valid Name: field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-test_values.py
+*.cfg
 *.pyc
 *.pyo
+*.tar.gz
+*/
+*~
+*\#*
+test_values.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 *.cfg
 *.pyc
 *.pyo
+*.spec
 *.tar.gz
 */
-*~
 *\#*
+*~
 test_values.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.2.2 (2017-09-06)
+## 1.2.2-2 (2018-05-03)
+- #65: Use .spec.in, not .spec file, to publish RPMs
+  - Add Makefile tools to build cleaner tarball, rpmbuild, and build with mock
+  - Update .gitignore to exclude subdirectories, generated .spec, and editor temp files
+
+## 1.2.2-1 (2017-09-06)
 - #59: Handle special value '__none__' for proxy (@andlam)
 
 ## 1.2.1 (2017-07-31)

--- a/yum-plugin-s3-iam.spec.in
+++ b/yum-plugin-s3-iam.spec.in
@@ -1,6 +1,7 @@
-Name:      %{name}
-Version:   %{version}
-Release:   %{release}
+# Values normally populated from Makefile
+Name:      @@@NAME@@@
+Version:   @@@VERSION@@@
+Release:   @@@RELEASE@@@
 Summary:   Yum package manager plugin for private S3 repositories.
 
 Group:     Application/SystemTools


### PR DESCRIPTION
See Issue #65. Build valid .spec file from .spec.in file, so SRPM has valid files, build tarball more efficiently, provide .gitignore and "make clean" options to better process local builds, add "mock" builds for multi-platform builds.