### PR TITLE
Overwrite for no proxy is _none_ according to man page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME    = yum-plugin-s3-iam
-VERSION = 1.2.2
+VERSION = 1.2.2p2
 RELEASE = 1
 ARCH    = noarch
 

--- a/s3iam.py
+++ b/s3iam.py
@@ -167,7 +167,7 @@ class S3Repository(YumRepository):
             proxy_config['https'] = os.environ['https_proxy']
         if 'http_proxy' in os.environ:
             proxy_config['http'] = os.environ['http_proxy']
-        if repo.proxy and repo.proxy != '__none__':
+        if repo.proxy and repo.proxy != '_none_':
             proxy_config['https'] = proxy_config['http'] = repo.proxy
         if proxy_config:
             proxy = urllib2.ProxyHandler(proxy_config)


### PR DESCRIPTION
According to yum.conf(5), overwriting the proxy settings from the environment uses the value `_none_` (one underliner).  Handling in the S3 plugin should be consistent.