### PR TITLE
Add s3-website and dualstack url support

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -74,9 +74,15 @@ def parse_url(url):
         return (m.group(2), None, m.group(3))
 
     # http[s]://<bucket>.s3-<aws-region>.amazonaws.com
-    m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3-([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
+    # http[s]://<bucket>.s3.<aws-region>.amazonaws.com
+    m = re.match(r'(http|https|s3)://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])[.]s3[-.]([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
     if m:
         return (m.group(2), m.group(3), m.group(4))
+
+    # http://<bucket>.s3-website.<aws-region>.amazonaws.com
+    m = re.match(r'http://([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])\.s3-website\.([a-z0-9-]+)[.]amazonaws[.]com(.*)$', url)
+    if m:
+        return (m.group(1), m.group(2), m.group(3))
 
     # http[s]://s3.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
@@ -90,6 +96,11 @@ def parse_url(url):
 
     # http[s]://s3-<region>.amazonaws.com/<bucket>
     m = re.match(r'(http|https|s3)://s3-([a-z0-9-]+)[.]amazonaws[.]com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
+    if m:
+        return (m.group(3), m.group(2), m.group(4))
+
+    # https://s3.dualstack.<region>.amazonaws.com/<bucket>
+    m = re.match(r'(http|https)://s3\.dualstack\.([a-z0-9-]+)\.s3-website\.com/([a-z0-9][a-z0-9-.]{1,61}[a-z0-9])(.*)$', url)
     if m:
         return (m.group(3), m.group(2), m.group(4))
 

--- a/tests.py
+++ b/tests.py
@@ -153,6 +153,16 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(r, 'us-west-2')
         self.assertEqual(p, '/path')
 
+        (b, r, p) = s3iam.parse_url('https://foo.s3.us-west-2.amazonaws.com/path')
+        self.assertEqual(b, 'foo')
+        self.assertEqual(r, 'us-west-2')
+        self.assertEqual(p, '/path')
+
+        (b, r, p) = s3iam.parse_url('https://foo.s3-website.us-west-2.amazonaws.com/path')
+        self.assertEqual(b, 'foo')
+        self.assertEqual(r, 'us-west-2')
+        self.assertEqual(p, '/path')
+
         (b, r, p) = s3iam.parse_url('https://s3.amazonaws.com/bar/path')
         self.assertEqual(b, 'bar')
         self.assertEqual(r, 'us-east-1')
@@ -168,6 +178,10 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(r, 'cn-north-1')
         self.assertEqual(p, '/path')
 
+        (b, r, p) = s3iam.parse_url('https://s3.dualstack.us-west-1.amazonaws.com/chicken-little/path')
+        self.assertEqual(b, 'chicken-little')
+        self.assertEqual(r, 'us-west-1')
+        self.assertEqual(p, '/path')
 
 class S3RepositoryTest(unittest.TestCase):
 


### PR DESCRIPTION
This adds support for the following urls:
  - `http://<bucket>.s3.<region>.amazonaws.com/<path>`
  - `https://foo.s3-website.<region>.amazonaws.com/<path>`
  - `https://s3.dualstack.<region>.amazonaws.com/<bucket>/<path>`

From https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region