### PR TITLE
Stop retrying 404 response from s3

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -353,6 +353,8 @@ class S3Grabber(object):
                     out.write(buff)
                     buff = response.read(BUFFER_SIZE)
             except urllib2.HTTPError, e:
+                if e.code == 404:
+                  retries = 0
                 if retries > 0:
                     time.sleep(delay)
                     delay *= self.backoff
@@ -463,3 +465,4 @@ class S3Grabber(object):
         request.add_header('x-amz-content-sha256', content_h)
         request.add_header('x-amz-date', amzdate)
         request.add_header('Authorization', auth)
+

--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -37,7 +37,7 @@ rm -rf ${RPM_BUILD_ROOT}
 /usr/lib/yum-plugins/s3iam.py*
 
 %changelog
-* Tue 28 Aug 2018 Piotr Kasperski <piotrkas@kainso.com>
+* Tue Aug 28 2018 Piotr Kasperski <piotrkas@kainso.com>
 - Added https://github.com/seporaitis/yum-s3-iam/pull/64
 
 * Fri May 05 2017 Mathias Brossard <mathias@brossard.org> 1.2.2-1


### PR DESCRIPTION
yum-s3-iam currently retries 404 responses from AWS indicating the key does not exist and should not be retried.