### PR TITLE
don't retry on 4xxs and timeout at 2^10 time vs 3^10 time

### DIFF
--- a/s3iam.py
+++ b/s3iam.py
@@ -351,9 +351,9 @@ class S3Grabber(object):
                     out.write(buff)
                     buff = response.read(BUFFER_SIZE)
             except urllib2.HTTPError, e:
-                if retries > 0:
+                if retries > 0 and (e.code > 499 or e.code < 400):
                     time.sleep(delay)
-                    delay *= self.backoff
+                    delay *= 2
                 else:
                     # Wrap exception as URLGrabError so that YumRepository catches it
                     from urlgrabber.grabber import URLGrabError


### PR DESCRIPTION
* if the repo xml file was missing this caused yum to hang indefinitely since it was retrying on 404, now it just fails immediately.

* the backoff was n^10 where n is the default backoff of 3, so 3^10 = aprox. 17 days.  this times out by default was reduced to ~51mins (3*2^10).