### PR TITLE
Use boto3 to manage credentials

### DIFF
--- a/yum-plugin-s3-iam.spec
+++ b/yum-plugin-s3-iam.spec
@@ -11,7 +11,7 @@ Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildArch: noarch
 
-Requires:  yum
+Requires:  yum, python2-boto3
 
 %description
 Yum package manager plugin for private S3 repositories.


### PR DESCRIPTION
The code previously used boto for delegated role credentials.  This patch advances that development line to use boto3 for all credential managment.

An important effect of this change is that the plugin now works in ECS docker contexts.