### PR TITLE
Set-up Github Workflow To Test RPM Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - '*'
+jobs:
+  test_rpmbuild_centos6:
+    runs-on: ubuntu-latest
+    name: Check the package builds on CentOS6
+    steps:
+    - name: rpmbuild on CentOS6
+      uses: seporaitis/rpmbuild-centos6-github-action@master
+      with:
+        command: make rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,23 @@ on:
 jobs:
   test_rpmbuild_centos6:
     runs-on: ubuntu-latest
-    name: Check the package builds on CentOS6
+    name: Package Builds On CentOS6
     steps:
     - uses: actions/checkout@v2
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
+      with:
+        # NOTE(seporaitis): rpmbuild doesn't like when spec is not owned by
+        # root.
+        command: (chown root:root *.spec; make rpm)
+
+  test_rpmbuild_centos7:
+    runs-on: ubuntu-latest
+    name: Package Builds On CentOS7
+    steps:
+    - uses: actions/checkout@v2
+    - name: rpmbuild on CentOS7
+      uses: seporaitis/rpmbuild-centos7-github-action@master
       with:
         # NOTE(seporaitis): rpmbuild doesn't like when spec is not owned by
         # root.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
-        command: (cd /github/workspace; echo "$(pwd)"; make test)
+        command: (cd /github/workspace; echo "$(pwd)"; ls -l; make test)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ jobs:
     name: CentOS6 RPMBuild
     steps:
     - uses: actions/checkout@v2
-    - name: rpmbuild on CentOS6
-      uses: seporaitis/rpmbuild-centos6-github-action@master
+    - uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
         # NOTE(seporaitis): rpmbuild doesn't like when spec is not owned by
         # root.
@@ -23,8 +22,7 @@ jobs:
     name: CentOS7 RPMBuild
     steps:
     - uses: actions/checkout@v2
-    - name: rpmbuild on CentOS7
-      uses: seporaitis/rpmbuild-centos7-github-action@master
+    - uses: seporaitis/rpmbuild-centos7-github-action@master
       with:
         # NOTE(seporaitis): rpmbuild doesn't like when spec is not owned by
         # root.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test_rpmbuild_centos6:
     runs-on: ubuntu-latest
-    name: Package Builds On CentOS6
+    name: CentOS6 RPMBuild
     steps:
     - uses: actions/checkout@v2
     - name: rpmbuild on CentOS6
@@ -20,7 +20,7 @@ jobs:
 
   test_rpmbuild_centos7:
     runs-on: ubuntu-latest
-    name: Package Builds On CentOS7
+    name: CentOS7 RPMBuild
     steps:
     - uses: actions/checkout@v2
     - name: rpmbuild on CentOS7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
-        command: (cd /github/workspace; make rpm)
+        command: (cd /github/workspace; echo "$(pwd)"; make test)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
-        command: make rpm
+        command: (cd /github/workspace; make rpm)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,6 @@ jobs:
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
-        command: (pwd; cd /github/workspace; echo "$(pwd)"; ls -l; chown root:root *.spec; make test)
+        # NOTE(seporaitis): rpmbuild doesn't like when spec is not owned by
+        # root.
+        command: (chown root:root *.spec; make rpm)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:
-        command: (cd /github/workspace; echo "$(pwd)"; ls -l; make test)
+        command: (pwd; cd /github/workspace; echo "$(pwd)"; ls -l; chown root:root *.spec; make test)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check the package builds on CentOS6
     steps:
+    - uses: actions/checkout@v2
     - name: rpmbuild on CentOS6
       uses: seporaitis/rpmbuild-centos6-github-action@master
       with:


### PR DESCRIPTION
It appears GitHub actions don't support CentOS out of the box, but it can run a docker container built from any image. This change uses [rpmbuild-centos6-github-action](https://github.com/seporaitis/rpmbuild-centos6-github-action) [rpmbuild-centos7-github-action](https://github.com/seporaitis/rpmbuild-centos7-github-action) to execute `make rpm` command as a first step in improving build process.

NOTE: I am aware that there are a couple of rpmbuild action options available on GitHub Marketplace, but they seem to require specific repository/file setup and I want to avoid big changes at first, as per #82. Also, I haven't worked with GitHub Actions and Workflows - so this'll let me get used to them bottom-up.